### PR TITLE
Force define() method to set a lazy evaluator in parser object.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+venv/*
+build/*
+dist/*
+
+*.egg-info/*
+.*
+!.gitignore
+
+# eclipse ide related stuff
+.project
+.pydevproject
+.settings/*
+*.pyc
+*.py~

--- a/funcparserlib/parser.py
+++ b/funcparserlib/parser.py
@@ -89,11 +89,13 @@ class Parser(object):
 
     def define(self, p):
         """Defines a parser wrapped into this object."""
-        f = getattr(p, 'run', p)
+        lazy_getter = (
+            lambda *args, **kwargs: getattr(p, 'run', p)(*args, **kwargs)
+        )
         if debug:
-            setattr(self, '_run', f)
+            setattr(self, '_run', lazy_getter)
         else:
-            setattr(self, 'run', f)
+            setattr(self, 'run', lazy_getter)
         self.named(getattr(p, 'name', p.__doc__))
 
     def run(self, tokens, s):


### PR DESCRIPTION
The problem is straight forward as hell - if you call ```parser0.define(parser1)``` and parser1 haven't been defined yet, you just copy its dummy run method realization, I think this is not the way it meant to be played. Following little fix adds more laziness to evaluation cascade.