### PR TITLE
Fix #44: make make_tokenizer return a list as parsers expect sequences

### DIFF
--- a/funcparserlib/lexer.py
+++ b/funcparserlib/lexer.py
@@ -103,11 +103,13 @@ def make_tokenizer(specs):
         length = len(str)
         line, pos = 1, 0
         i = 0
+        r = []
         while i < length:
             t = match_specs(compiled, str, i, (line, pos))
-            yield t
+            r.append(t)
             line, pos = t.end
             i += len(t.value)
+        return r
 
     return f
 

--- a/funcparserlib/tests/test_parsing.py
+++ b/funcparserlib/tests/test_parsing.py
@@ -67,3 +67,10 @@ end"""
             self.assertEqual((t.start, t.end), ((2, 11), (2, 14)))
         else:
             self.fail(u'must raise NoParseError')
+
+    def test_tokenize_generator(self):
+        tokenize = make_tokenizer([
+            (u'x', (ur'x',)),
+        ])
+
+        some(lambda t: t.type == "x").parse(tokenize("x"))


### PR DESCRIPTION
Fixes #44.
