### PR TITLE
Add universal wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Wheels are the new standard of python distribution.

For detailed information, see [PEP 427](https://www.python.org/dev/peps/pep-0427/).

For high level information, see: https://pythonwheels.com/

Advantages of wheels

* Faster installation for pure Python packages
* Avoids arbitrary code execution for installation (avoids setup.py)
* Allows better caching for testing and continuous integration
* Creates .pyc files as part of installation to ensure they match the python interpreter used
* More consistent installs across platforms and machines

As this package is pure Pythong (no C files), I have marked the wheel as universal.

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`.