### PR TITLE
Update URLs throughout project

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Show Me the Code
 ----------------
 
 This is an excerpt from a JSON parser ([RFC
-4627](http://tools.ietf.org/html/rfc4627)) written using `funcparserlib`. This
+4627](https://tools.ietf.org/html/rfc4627)) written using `funcparserlib`. This
 full example as well as others can be found [here](funcparserlib/tests/json.py).
 
 ```python
@@ -121,8 +121,8 @@ Despite being an LL(`*`) parser, `funcparserlib` has a reasonable performance. F
 Similar Projects
 ----------------
 
-  * [LEPL](http://code.google.com/p/lepl/). A recursive descent parsing library that uses two-way generators for backtracking. Its source code is rather large: 17 KLOC
-  * [pyparsing](http://pyparsing.wikispaces.com/). A recursive descent parsing library. Probably the most popular Python parsing library. Nevertheless its source code is quite dirty (though 4 KLOC only)
+  * [LEPL](https://code.google.com/p/lepl/). A recursive descent parsing library that uses two-way generators for backtracking. Its source code is rather large: 17 KLOC
+  * [pyparsing](https://github.com/pyparsing/pyparsing/). A recursive descent parsing library. Probably the most popular Python parsing library. Nevertheless its source code is quite dirty (though 4 KLOC only)
   * [Monadic Parsing in Python](http://sandersn.com/blog/index.php?title=monadic_parsing_in_python_part_3&more=1&c=1&tb=1&pb=1). A series of blog entries on monadic parsing
   * [Pysec (aka Parsec in Python)](http://www.valuedlessons.com/2008/02/pysec-monadic-combinatoric-parsing-in.html). A blog entry on monadic parsing, with nice syntax for Python
 

--- a/doc/Brackets.md
+++ b/doc/Brackets.md
@@ -8,14 +8,14 @@ Nested Brackets Mini-HOWTO
   </dd>
   <dt>License:</dt>
   <dd>
-    <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">
+    <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">
       Creative Commons Attribution-Noncommercial-Share Alike 3.0
     </a>
   </dd>
   <dt>Library Homepage:</dt>
   <dd>
-    <a href="http://code.google.com/p/funcparserlib/">
-      http://code.google.com/p/funcparserlib/
+    <a href="https://github.com/vlasovskikh/funcparserlib">
+      https://github.com/vlasovskikh/funcparserlib
     </a>
   </dd>
   <dt>Library Version:</dt>
@@ -32,7 +32,7 @@ so we need a parser. For more complex examples see [The funcparserlib
 Tutorial][tutorial] or
 other examples at [the funcparserlib homepage][funcparserlib].
 
-  [funcparserlib]: http://code.google.com/p/funcparserlib/
+  [funcparserlib]: https://github.com/vlasovskikh/funcparserlib
   [tutorial]: http://archlinux.folding-maps.org/2009/funcparserlib/Tutorial
 
 Here is the EBNF grammar of our curly brackets language:

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -58,5 +58,5 @@ while `p3`, `p7`, and `p8` are is not. Parsers `p2`, `p6`, and `p7` may enter an
 infinite loop, while others cannot. Just apply the statements we have made
 above to these parsers to figure out why.
 
-  [1]: http://code.google.com/p/funcparserlib/
+  [1]: https://github.com/vlasovskikh/funcparserlib
 

--- a/doc/Illustrated.md
+++ b/doc/Illustrated.md
@@ -8,14 +8,14 @@ Parsing Stages Illustrated
   </dd>
   <dt>License:</dt>
   <dd>
-    <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">
+    <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">
       Creative Commons Attribution-Noncommercial-Share Alike 3.0
     </a>
   </dd>
   <dt>Library Homepage:</dt>
   <dd>
-    <a href="http://code.google.com/p/funcparserlib/">
-      http://code.google.com/p/funcparserlib/
+    <a href="https://github.com/vlasovskikh/funcparserlib">
+      https://github.com/vlasovskikh/funcparserlib
     </a>
   </dd>
   <dt>Library Version:</dt>
@@ -135,8 +135,8 @@ Then you can:
 See [the source code][dot-py] of the DOT parser and the docs at [the funcparserlib
 homepage][funcparserlib] for details.
 
-  [dot]: http://www.graphviz.org/
-  [dot-grammar]: http://www.graphviz.org/doc/info/lang.html
-  [funcparserlib]: http://code.google.com/p/funcparserlib/
-  [dot-py]: http://code.google.com/p/funcparserlib/source/browse/examples/dot/dot.py
+  [dot]: https://www.graphviz.org/
+  [dot-grammar]: https://www.graphviz.org/doc/info/lang.html
+  [funcparserlib]: https://github.com/vlasovskikh/funcparserlib
+  [dot-py]: https://github.com/vlasovskikh/funcparserlib
 

--- a/doc/Tutorial.md
+++ b/doc/Tutorial.md
@@ -8,14 +8,14 @@ The `funcparserlib` Tutorial
   </dd>
   <dt>License:</dt>
   <dd>
-    <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">
+    <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">
       Creative Commons Attribution-Noncommercial-Share Alike 3.0
     </a>
   </dd>
   <dt>Library Homepage:</dt>
   <dd>
-    <a href="http://code.google.com/p/funcparserlib/">
-      http://code.google.com/p/funcparserlib/
+    <a href="https://github.com/vlasovskikh/funcparserlib">
+      https://github.com/vlasovskikh/funcparserlib
     </a>
   </dd>
   <dt>Library Version:</dt>
@@ -1255,15 +1255,15 @@ instances for parsers:
         mappend x y = x | y
 
 
-  [doctest]: http://docs.python.org/library/doctest.html
-  [tokenize]: http://docs.python.org/library/tokenize.html
-  [funcparserlib]: http://code.google.com/p/funcparserlib/
-  [funcparserlib-issues]: http://code.google.com/p/funcparserlib/issues/list
-  [dot-parser]: http://code.google.com/p/funcparserlib/source/browse/examples/dot/dot.py
-  [json-parser]: http://code.google.com/p/funcparserlib/source/browse/examples/json/json.py
+  [doctest]: https://docs.python.org/library/doctest.html
+  [tokenize]: https://docs.python.org/library/tokenize.html
+  [funcparserlib]: https://github.com/vlasovskikh/funcparserlib
+  [funcparserlib-issues]: https://github.com/vlasovskikh/funcparserlib/issues
+  [dot-parser]: https://github.com/vlasovskikh/funcparserlib/blob/master/funcparserlib/tests/dot.py
+  [json-parser]: https://github.com/vlasovskikh/funcparserlib/blob/master/funcparserlib/tests/json.py
   [nested]: http://archlinux.folding-maps.org/2009/funcparserlib/Brackets
-  [sequences]: http://www.python.org/dev/peps/pep-3119/#sequences
-  [parser-py]:  http://code.google.com/p/funcparserlib/source/browse/src/funcparserlib/parser.py
+  [sequences]: https://www.python.org/dev/peps/pep-3119/#sequences
+  [parser-py]:  https://github.com/vlasovskikh/funcparserlib/blob/master/funcparserlib/parser.py
 
 
 ### Papers on Functional Parsers

--- a/funcparserlib/parser.py
+++ b/funcparserlib/parser.py
@@ -27,8 +27,8 @@ Basic combinators are taken from Harrison's book ["Introduction to Functional
 Programming"][1] and translated from ML into Python. See also [a Russian
 translation of the book][2].
 
-  [1]: http://www.cl.cam.ac.uk/teaching/Lectures/funprog-jrh-1996/
-  [2]: http://code.google.com/p/funprog-ru/
+  [1]: https://www.cl.cam.ac.uk/teaching/Lectures/funprog-jrh-1996/
+  [2]: https://github.com/funprog-ru/
 
 A parser `p` is represented by a function of type:
 

--- a/funcparserlib/tests/dot.py
+++ b/funcparserlib/tests/dot.py
@@ -12,7 +12,7 @@ not supported things:
 At the moment, the parser builds only a parse tree, not an abstract syntax tree
 (AST) or an API for dealing with DOT.
 
-  [1]: http://www.graphviz.org/doc/info/lang.html
+  [1]: https://www.graphviz.org/doc/info/lang.html
 """
 
 import sys

--- a/funcparserlib/tests/json.py
+++ b/funcparserlib/tests/json.py
@@ -4,7 +4,7 @@ r"""A JSON parser using funcparserlib.
 
 The parser is based on [the JSON grammar][1].
 
-  [1]: http://tools.ietf.org/html/rfc4627
+  [1]: https://tools.ietf.org/html/rfc4627
 """
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     description='Recursive descent parsing library based on functional '
         'combinators',
     license='MIT',
-    url='http://code.google.com/p/funcparserlib/',
+    url='https://github.com/vlasovskikh/funcparserlib',
     **extra)


### PR DESCRIPTION
- Use GitHub URLs instead of defunct Google Code
- Use https:// URLs when available
- Update pyparsing URL as wikispaces has closed