### PR TITLE
Fixes bug in equality operator in Token class

### DIFF
--- a/funcparserlib/lexer.py
+++ b/funcparserlib/lexer.py
@@ -49,7 +49,10 @@ class Token(object):
 
     def __eq__(self, other):
         # FIXME: Case sensitivity is assumed here
-        return self.type == other.type and self.value == other.value
+        if other is None:
+            return False
+        else:
+            return self.type == other.type and self.value == other.value
 
     def _pos_str(self):
         if self.start is None or self.end is None:


### PR DESCRIPTION
Currently, equality operator (==) in class Token doesn't check if the argument `other` is None, leading to the exception
```
AttributeError: 'NoneType' object has no attribute 'type'
```

This pull request fixes the bug by returning False if `other` is None