### PR TITLE
Replace deprecated `setup.py test` with unittest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,4 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
-    tests_require=["six"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,6 @@
 envlist = py{27,35,36,37,38}
 
 [testenv]
-commands = python setup.py test
+deps =
+    six
+commands = python -m unittest discover


### PR DESCRIPTION
The setuptools test command has been formally deprecated since version
41.5.0 (27 Oct 2019). The project recommends replacing its use with tox
as a project level testing entrypoint.

Fixes the warning when running tests:

> WARNING: Testing via this command is deprecated and will be removed in
> a future version. Users looking for a generic test entry point
> independent of test runner are encouraged to use tox.

For more details, see the setuptools history:
https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0

And the command's documentation:
https://setuptools.readthedocs.io/en/latest/setuptools.html#test-build-package-and-run-a-unittest-suite